### PR TITLE
Network State snackbar

### DIFF
--- a/app/src/main/java/com/example/jetpack_compose_all_in_one/features/internet/InternetViewModel.kt
+++ b/app/src/main/java/com/example/jetpack_compose_all_in_one/features/internet/InternetViewModel.kt
@@ -1,0 +1,32 @@
+package com.example.jetpack_compose_all_in_one.features.internet
+
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
+import android.net.NetworkRequest
+import androidx.compose.runtime.mutableStateOf
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class InternetViewModel @Inject constructor(): ViewModel() {
+    val networkState = mutableStateOf<NetworkState>(NetworkState.Connected)
+
+    // Doesn't support cellular data yet
+    val networkRequest = NetworkRequest.Builder()
+        .addTransportType(NetworkCapabilities.TRANSPORT_WIFI)
+        .build()
+
+    val networkCallback = object: ConnectivityManager.NetworkCallback(){
+        override fun onAvailable(network: Network) {
+            super.onAvailable(network)
+            networkState.value = NetworkState.Connected
+        }
+
+        override fun onLost(network: Network) {
+            super.onLost(network)
+            networkState.value = NetworkState.Disconnected
+        }
+    }
+}

--- a/app/src/main/java/com/example/jetpack_compose_all_in_one/features/internet/NetworkState.kt
+++ b/app/src/main/java/com/example/jetpack_compose_all_in_one/features/internet/NetworkState.kt
@@ -1,0 +1,6 @@
+package com.example.jetpack_compose_all_in_one.features.internet
+
+sealed class NetworkState {
+    object Connected: NetworkState()
+    object Disconnected: NetworkState()
+}

--- a/app/src/main/java/com/example/jetpack_compose_all_in_one/ui/components/MainContainerOfApp.kt
+++ b/app/src/main/java/com/example/jetpack_compose_all_in_one/ui/components/MainContainerOfApp.kt
@@ -22,6 +22,7 @@ import com.example.jetpack_compose_all_in_one.R
 import com.example.jetpack_compose_all_in_one.features.alarm.AlarmMainUI
 import com.example.jetpack_compose_all_in_one.features.chatmodule.ChatViewModel
 import com.example.jetpack_compose_all_in_one.features.download_manager.Download
+import com.example.jetpack_compose_all_in_one.features.internet.InternetViewModel
 import com.example.jetpack_compose_all_in_one.features.login_style_1.LoginPage
 import com.example.jetpack_compose_all_in_one.features.login_style_2.LoginScreen2
 import com.example.jetpack_compose_all_in_one.features.login_style_1.LoginStyle1ViewModel
@@ -32,6 +33,7 @@ import com.example.jetpack_compose_all_in_one.lessons.lesson_2.Lesson_2_Chapter_
 import com.example.jetpack_compose_all_in_one.lessons.lesson_2.Lesson_2_Chapter_Shape
 import com.example.jetpack_compose_all_in_one.lessons.lesson_2.Lesson_2_Screen
 import com.example.jetpack_compose_all_in_one.ui.views.chat.DemoFullChat2
+import com.example.jetpack_compose_all_in_one.ui.views.internet.InternetDemo
 import com.example.jetpack_compose_all_in_one.ui.views.lessons.ComposeLayouts
 import com.example.jetpack_compose_all_in_one.ui.views.quote_swipe.QuoteSwipe
 import com.example.jetpack_compose_all_in_one.ui.views.news_ui.LatestNewsPage
@@ -44,7 +46,7 @@ import kotlinx.coroutines.launch
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun MainContainerOfApp(
-    isOffline: Boolean = false,
+    internetViewModel: InternetViewModel,
     playMusicFuncForeground: (Uri) -> Unit,
     stopMusicFuncForeground: () -> Unit,
     playMusicFuncBound: (Uri) -> Unit,
@@ -79,18 +81,14 @@ fun MainContainerOfApp(
                     )
                 }
             },
-            snackbarHost = { SnackbarShow(snackbarHostState, isOffline) }
+            snackbarHost = { SnackbarShow(snackbarHostState, internetViewModel.networkState) }
         ) {
             NavHost(navController, currentRoute.value.route(), Modifier.padding(it)) {
                 composable(NavDes.Home.route()) {
                     Box {}
                 }
                 composable(NavDes.Internet.route()) {
-                    if (isOffline) {
-                        NetworkErrorDialog()
-                    } else {
-                        Text("Internet available")
-                    }
+                    InternetDemo()
                 }
                 composable(NavDes.ForegroundService.route()) {
                     Box(

--- a/app/src/main/java/com/example/jetpack_compose_all_in_one/ui/components/snackbar.kt
+++ b/app/src/main/java/com/example/jetpack_compose_all_in_one/ui/components/snackbar.kt
@@ -9,7 +9,11 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.MutableState
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import com.example.jetpack_compose_all_in_one.R
+import com.example.jetpack_compose_all_in_one.features.internet.NetworkState
 import com.example.jetpack_compose_all_in_one.ui.theme.dp_0
 import com.example.jetpack_compose_all_in_one.ui.theme.dp_10
 import com.example.jetpack_compose_all_in_one.ui.theme.dp_24
@@ -62,18 +66,16 @@ fun SnackbarHost(
 @Composable
 fun SnackbarShow(
     snackbarHostState: SnackbarHostState,
-    isOffline: Boolean = false
+    networkState: MutableState<NetworkState>
 ) {
     if (snackbarHostState.currentSnackbarData == null) {
-        if (isOffline) {
-            Snackbar(
-                action = {
-                    Button(onClick = {}) {
-                        Text("MyAction")
-                    }
-                },
-                modifier = Modifier.padding(dp_10, dp_0, dp_10, dp_24)
-            ) { Text(text = "This is a snackbar!") }
+        when (networkState.value) {
+            NetworkState.Connected -> {}
+            NetworkState.Disconnected -> {
+                Snackbar(
+                    modifier = Modifier.padding(dp_10, dp_0, dp_10, dp_24)
+                ) { Text(text = stringResource(R.string.no_internet)) }
+            }
         }
     } else {
         SnackbarHost(snackbarHostState)

--- a/app/src/main/java/com/example/jetpack_compose_all_in_one/ui/views/internet/InternetDemo.kt
+++ b/app/src/main/java/com/example/jetpack_compose_all_in_one/ui/views/internet/InternetDemo.kt
@@ -1,0 +1,8 @@
+package com.example.jetpack_compose_all_in_one.ui.views.internet
+
+import androidx.compose.runtime.Composable
+
+@Composable
+fun InternetDemo() {
+
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -12,4 +12,5 @@
     <string name="no_internet_connected">No internet connected!! \n</string>
     <string name="try_again">Try again\n</string>
     <string name="set_alarm">Set Alarm</string>
+    <string name="no_internet">No Internet</string>
 </resources>


### PR DESCRIPTION
- Added a snackbar when there is no internet (Currently ignores data. Only checks WiFi)

Note: Without internet, the app silently crashes whenever we use retrofit. Make an interceptor to stop the retrofit request in the future.